### PR TITLE
Removed old 0.3.0 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,10 @@ cache:
   
 env:
   - SIMPHONY_VERSION=master
-  - SIMPHONY_VERSION=0.3.0
   - SIMPHONY_VERSION=413eb6f5683c4733b943c300c3192265c79ac26b
 matrix:
   allow_failures:
     - env: SIMPHONY_VERSION=master
-    - env: SIMPHONY_VERSION=0.3.0
 
 before_install:
   - sudo apt-get update -qq


### PR DESCRIPTION
0.3.0 is incompatible, there's no point of slowing down testing